### PR TITLE
build: replace deprecated gcc::Config::new with gcc::Build::new

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,7 @@ fn fetch() -> io::Result<()> {
 
 #[cfg(target_os = "linux")]
 fn build() -> io::Result<()> {
-	let mut config = gcc::Config::new();
+	let mut config = gcc::Build::new();
 
 	config.file(source().join("libusb/hid.c"));
 	config.include(source().join("hidapi"));
@@ -54,7 +54,7 @@ fn build() -> io::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn build() -> io::Result<()> {
-	let mut config = gcc::Config::new();
+	let mut config = gcc::Build::new();
 
 	config.file(source().join("libusb/hid.c"));
 	config.include(source().join("hidapi"));
@@ -70,7 +70,7 @@ fn build() -> io::Result<()> {
 
 #[cfg(target_os = "windows")]
 fn build() -> io::Result<()> {
-	let mut config = gcc::Config::new();
+	let mut config = gcc::Build::new();
 
 	config.file(source().join("windows/hid.c"));
 	config.include(source().join("hidapi"));


### PR DESCRIPTION
The gcc crate deprecated gcc::Config in favor of gcc::Build, resulting
in a compile warning:

> warning: use of deprecated item: gcc::Config has been renamed to gcc::Build
>   --> build.rs:41:19
>    |
> 41 |    let mut config = gcc::Config::new();
>    |                     ^^^^^^^^^^^^^^^^
>    |
>    = note: #[warn(deprecated)] on by default

This change makes the build.rs script adhere to the renaming, thereby
getting rid of the warning.