### PR TITLE
Resolve conflict with system-wide static libhidapi-libusb.a library

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,7 +57,7 @@ fn build() -> io::Result<()> {
 		build.include(path.to_str().unwrap());
 	}
 
-	build.compile("libhidapi-libusb.a");
+	build.compile("libhidapi-libusb-rust.a");
 
 	Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@ extern "C" { }
 #[cfg_attr(target_os = "windows", link(name = "setupapi"))]
 extern "C" { }
 
-#[cfg_attr(all(feature = "static", target_os = "linux"), link(name = "hidapi-libusb", kind = "static"))]
+#[cfg_attr(all(feature = "static", not(feature = "build"), target_os = "linux"), link(name = "hidapi-libusb", kind = "static"))]
+#[cfg_attr(all(feature = "static", feature = "build", target_os = "linux"), link(name = "hidapi-libusb-rust", kind = "static"))]
 #[cfg_attr(all(not(feature = "static"), target_os = "linux"), link(name = "hidapi-libusb"))]
 #[cfg_attr(all(feature = "static", not(target_os = "linux")), link(name = "hidapi", kind = "static"))]
 #[cfg_attr(all(not(feature = "static"), not(target_os = "linux")), link(name = "hidapi"))]


### PR DESCRIPTION
This PR fixes issue #4.

How to reproduce the problem:
1. target_os = linux
2. Install `libhidapi-dev` package (that contains `libhidapi-libusb.a` static library).
3. Link executable with `hidapi-sys` crate with 'build' feature.

The problem: rust is trying to link executable with system-wide `libhidapi-libusb.a` instead of the library that was generated by build script (`build.rs`). But the system-wide library is built without `-fPIC` flag so we get the error: 'relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC'.

This happens because the build script generates a library that has the same filename as the system-wide library.

Solution: use a distinct filename for the static library in `build.rs` to resolve the conflict.